### PR TITLE
Support for non-release builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,4 @@
 version: 1.0.0.{build}
-branches:
-  only:
-  - master
 image: Visual Studio 2015
 assembly_info:
   patch: true
@@ -17,6 +14,10 @@ artifacts:
 - path: artifacts/tests/*
 deploy:
 - provider: NuGet
+# NuGet deployment on master tags only 
+  on: 
+    branch: master
+    appveyor_repo_tag: true
   api_key:
     secure: BJIZ1k2V8xaB2U8rS/vM8BJwihpdWE0yhzscE+VTAvPCfEpUvLVV7vfkZCmBpZoK
 on_finish:


### PR DESCRIPTION
Appveyor now configured to support release deployments only from tagged changes on master
